### PR TITLE
Update topics to reflect iOS app removal

### DIFF
--- a/_topic/ios-app-unavailable.md
+++ b/_topic/ios-app-unavailable.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: "iOS app removed from App Store"
+prompt: "The Pebble iOS app is not on the App Store"
+keywords: "removed removal appstore apple iphone jailbreak"
+date:   2021-10-04 12:00:00
+author: "Will0"
+hideFirstStepNumber: true
+---
+
+# iOS app removal 
+
+On the 4th of October 2021 the Pebble app was removed from the iOS App Store. That means new users who do not already have the Pebble app installed on their iPhones will not be able to download it.
+
+Users who already have the app installed should be fine so long as they do not uninstall it.
+
+While Rebble are working on a replacement app, it is not yet ready for use. If you are an iOS developer, [get in touch!](https://rebble.io/contact)
+
+Unfortunately at this time there is no workaround we can suggest for new iOS users who don't have the app. For further questions, [join us on Discord](https://rebble.io/discord).

--- a/_topic/setup-ios.md
+++ b/_topic/setup-ios.md
@@ -4,29 +4,20 @@ title: "Setup Rebble Web Services"
 prompt: "I need help setting up Rebble Web Services"
 date:   2021-02-01 07:14:42
 author: "Will0"
+hideFirstStepNumber: true
 
 osSpecific: true
 os: ios
 ---
 
-# Connect your Pebble to its charger   
+# iOS app removal 
 
-Connect your Pebble to a plugged in USB charging cable. You really wouldn't want it to lose power in the middle of a firmware update! Once the watch is powered on, press the left button to dismiss the charging screen.
+On the 4th of October 2021 the Pebble app was removed from the iOS App Store. That means new users who do not already have the Pebble app installed on their iPhones will not be able to download it.
 
-# Install the app from the App Store
+While Rebble are working on a replacement app, it is not yet ready for use.
 
-On your iPhone, download the Pebble app from the App Store:
+If you already have the Pebble app installed but not set up, continue with the guide.
 
-[App Store Link](https://itunes.apple.com/en/app/pebble/id957997620?mt=8)
-
-<notmobile>
-
-or via this QR code:   
-
-<qr url="https://itunes.apple.com/en/app/pebble/id957997620?mt=8" />
-
-</notmobile>
-   
 # Open the Pebble app
 
 If prompted, allow the Pebble app to turn on Bluetooth.


### PR DESCRIPTION
Unfortunately the iOS app is now gone from the iOS App Store. 

This PR adjusts the iOS setup instructions to reflect this, and also adds a dedicated help topic explaining the situation