### PR TITLE
add restricted settings link to setup-android

### DIFF
--- a/_topic/setup-android.md
+++ b/_topic/setup-android.md
@@ -99,6 +99,10 @@ Run through the Pebble setup screens. Make sure you allow notification access:
 
 ![](/images/setup/8.png)
 
+<sub>Please note you might have to enable [restricted settings](https://help.rebble.io/android-restricted-settings) on Android 13+ </sub>
+
+
+
 
 # Complete the Pebble pairing
 


### PR DESCRIPTION
Something I noticed while other PR's were being merged. Just a quality-of-life thing.